### PR TITLE
feat: Configuration UI & Settings Panel (#6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,22 @@
       {
         "command": "vaultguard.addSKUToBlocklist",
         "title": "VaultGuard: Add SKU to Blocklist"
+      },
+      {
+        "command": "vaultguard.removeSKUFromBlocklist",
+        "title": "Remove from Blocklist",
+        "icon": "$(trash)"
       }
-    ]
+    ],
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "vaultguard.removeSKUFromBlocklist",
+          "when": "view == vaultguard.configuration && viewItem == blocked-sku",
+          "group": "inline"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,74 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "VaultGuard",
+      "properties": {
+        "vaultguard.rules.dataResidency.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable OSFI B-10 data residency checks"
+        },
+        "vaultguard.rules.secrets.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable OSFI B-13 secrets management checks"
+        },
+        "vaultguard.rules.encryption.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable OSFI B-13 encryption checks"
+        },
+        "vaultguard.rules.portability.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable OSFI B-10 portability checks"
+        },
+        "vaultguard.rules.costOptimization.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable cost optimization warnings"
+        },
+        "vaultguard.skus.allowlist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "SKUs to allow (if set, only these SKUs are permitted)"
+        },
+        "vaultguard.skus.blocklist": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["t3.2xlarge", "m5.4xlarge", "r5.4xlarge"],
+          "description": "SKUs to block/disallow"
+        },
+        "vaultguard.costThreshold": {
+          "type": "number",
+          "default": 100,
+          "description": "Monthly cost threshold for warnings (USD)"
+        }
+      }
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "vaultguard",
+          "title": "VaultGuard",
+          "icon": "resources/shield.svg"
+        }
+      ]
+    },
+    "views": {
+      "vaultguard": [
+        {
+          "id": "vaultguard.configuration",
+          "name": "Configuration"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "vaultguard.scan",
@@ -25,6 +93,14 @@
       {
         "command": "vaultguard.scanAndCommit",
         "title": "VaultGuard: Scan & Populate Commit"
+      },
+      {
+        "command": "vaultguard.toggleRule",
+        "title": "VaultGuard: Toggle Rule"
+      },
+      {
+        "command": "vaultguard.addSKUToBlocklist",
+        "title": "VaultGuard: Add SKU to Blocklist"
       }
     ]
   },

--- a/resources/shield.svg
+++ b/resources/shield.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2L3 7V12C3 16.55 6.84 20.74 12 22C17.16 20.74 21 16.55 21 12V7L12 2Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M9 12L11 14L15 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/config/settingsManager.ts
+++ b/src/config/settingsManager.ts
@@ -1,0 +1,91 @@
+import * as vscode from 'vscode';
+
+export interface VaultGuardSettings {
+    rules: {
+        dataResidency: { enabled: boolean };
+        secrets: { enabled: boolean };
+        encryption: { enabled: boolean };
+        portability: { enabled: boolean };
+        costOptimization: { enabled: boolean };
+    };
+    skus: {
+        allowlist: string[];
+        blocklist: string[];
+    };
+    costThreshold: number;
+}
+
+export class SettingsManager {
+    private static instance: SettingsManager;
+    private config: vscode.WorkspaceConfiguration;
+    private _onDidChangeSettings: vscode.EventEmitter<VaultGuardSettings> = new vscode.EventEmitter<VaultGuardSettings>();
+    readonly onDidChangeSettings: vscode.Event<VaultGuardSettings> = this._onDidChangeSettings.event;
+
+    private constructor() {
+        this.config = vscode.workspace.getConfiguration('vaultguard');
+        
+        // Watch for configuration changes
+        vscode.workspace.onDidChangeConfiguration(e => {
+            if (e.affectsConfiguration('vaultguard')) {
+                this.config = vscode.workspace.getConfiguration('vaultguard');
+                this._onDidChangeSettings.fire(this.getSettings());
+            }
+        });
+    }
+
+    static getInstance(): SettingsManager {
+        if (!SettingsManager.instance) {
+            SettingsManager.instance = new SettingsManager();
+        }
+        return SettingsManager.instance;
+    }
+
+    getSettings(): VaultGuardSettings {
+        return {
+            rules: {
+                dataResidency: {
+                    enabled: this.config.get('rules.dataResidency.enabled', true)
+                },
+                secrets: {
+                    enabled: this.config.get('rules.secrets.enabled', true)
+                },
+                encryption: {
+                    enabled: this.config.get('rules.encryption.enabled', true)
+                },
+                portability: {
+                    enabled: this.config.get('rules.portability.enabled', true)
+                },
+                costOptimization: {
+                    enabled: this.config.get('rules.costOptimization.enabled', true)
+                }
+            },
+            skus: {
+                allowlist: this.config.get('skus.allowlist', []),
+                blocklist: this.config.get('skus.blocklist', ['t3.2xlarge', 'm5.4xlarge', 'r5.4xlarge'])
+            },
+            costThreshold: this.config.get('costThreshold', 100)
+        };
+    }
+
+    async updateSetting(key: string, value: any, global: boolean = false): Promise<void> {
+        await this.config.update(key, value, global ? vscode.ConfigurationTarget.Global : vscode.ConfigurationTarget.Workspace);
+    }
+
+    isRuleEnabled(ruleName: string): boolean {
+        const settings = this.getSettings();
+        const rule = (settings.rules as any)[ruleName];
+        return rule ? rule.enabled : true;
+    }
+
+    isSKUAllowed(sku: string): boolean {
+        const { allowlist, blocklist } = this.getSettings().skus;
+        
+        // If allowlist is populated, only those SKUs are allowed
+        if (allowlist.length > 0) {
+            return allowlist.includes(sku);
+        }
+        
+        // Otherwise, check if SKU is in blocklist
+        return !blocklist.includes(sku);
+    }
+}

--- a/src/config/skuCatalog.ts
+++ b/src/config/skuCatalog.ts
@@ -1,0 +1,50 @@
+// Common SKU catalog for cloud providers
+export const SKU_CATALOG = {
+    AWS: {
+        compute: [
+            't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge',
+            'm5.large', 'm5.xlarge', 'm5.2xlarge', 'm5.4xlarge', 'm5.8xlarge',
+            'r5.large', 'r5.xlarge', 'r5.2xlarge', 'r5.4xlarge', 'r5.8xlarge',
+            'c5.large', 'c5.xlarge', 'c5.2xlarge', 'c5.4xlarge'
+        ],
+        database: [
+            'db.t3.micro', 'db.t3.small', 'db.t3.medium', 'db.t3.large',
+            'db.m5.large', 'db.m5.xlarge', 'db.m5.2xlarge',
+            'db.r5.large', 'db.r5.xlarge', 'db.r5.2xlarge'
+        ]
+    },
+    Azure: {
+        compute: [
+            'Standard_B1s', 'Standard_B2s', 'Standard_B4ms',
+            'Standard_D2s_v3', 'Standard_D4s_v3', 'Standard_D8s_v3',
+            'Standard_E2s_v3', 'Standard_E4s_v3', 'Standard_E8s_v3'
+        ]
+    },
+    GCP: {
+        compute: [
+            'n1-standard-1', 'n1-standard-2', 'n1-standard-4', 'n1-standard-8',
+            'n2-standard-2', 'n2-standard-4', 'n2-standard-8',
+            'e2-micro', 'e2-small', 'e2-medium', 'e2-standard-2', 'e2-standard-4'
+        ]
+    }
+};
+
+export function getAllSKUs(): string[] {
+    const allSKUs: string[] = [];
+    for (const provider in SKU_CATALOG) {
+        const categories = (SKU_CATALOG as any)[provider];
+        for (const category in categories) {
+            allSKUs.push(...categories[category]);
+        }
+    }
+    return allSKUs;
+}
+
+export function getSKUsByProvider(provider: 'AWS' | 'Azure' | 'GCP'): string[] {
+    const skus: string[] = [];
+    const categories = SKU_CATALOG[provider];
+    for (const category in categories) {
+        skus.push(...(categories as any)[category]);
+    }
+    return skus;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,9 @@ import * as vscode from 'vscode';
 import { scanContent } from './scanner';
 import { RegionFixProvider } from './fixes/regionFix';
 import { scanAndCommit } from './commands/scanAndCommit';
+import { ConfigurationViewProvider } from './views/configurationView';
+import { SettingsManager } from './config/settingsManager';
+import { SKU_CATALOG, getAllSKUs } from './config/skuCatalog';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('VaultGuard is now active!');
@@ -9,9 +12,110 @@ export function activate(context: vscode.ExtensionContext) {
     const diagnosticCollection = vscode.languages.createDiagnosticCollection('vaultguard');
     context.subscriptions.push(diagnosticCollection);
 
+    // Initialize Settings Manager
+    const settingsManager = SettingsManager.getInstance();
+
+    // Register Configuration View
+    const configView = new ConfigurationViewProvider();
+    context.subscriptions.push(
+        vscode.window.registerTreeDataProvider('vaultguard.configuration', configView)
+    );
+
     // Register Commands
     context.subscriptions.push(
         vscode.commands.registerCommand('vaultguard.scanAndCommit', scanAndCommit)
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vaultguard.toggleRule', async (ruleName: string) => {
+            const settings = settingsManager.getSettings();
+            const currentValue = (settings.rules as any)[ruleName]?.enabled ?? true;
+            await settingsManager.updateSetting(`rules.${ruleName}.enabled`, !currentValue);
+            vscode.window.showInformationMessage(`${ruleName} rule ${!currentValue ? 'enabled' : 'disabled'}`);
+            configView.refresh();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vaultguard.addSKUToBlocklist', async () => {
+            // Step 1: Select cloud provider
+            const provider = await vscode.window.showQuickPick(
+                ['AWS', 'Azure', 'GCP', 'Custom (enter manually)'],
+                { placeHolder: 'Select cloud provider' }
+            );
+            
+            if (!provider) { return; }
+            
+            let sku: string | undefined;
+            
+            if (provider === 'Custom (enter manually)') {
+                sku = await vscode.window.showInputBox({
+                    prompt: 'Enter SKU to block',
+                    placeHolder: 't3.2xlarge'
+                });
+            } else {
+                // Step 2: Select SKU from provider catalog
+                const providerKey = provider as 'AWS' | 'Azure' | 'GCP';
+                const catalog = SKU_CATALOG[providerKey];
+                const skusByCategory: { label: string, sku: string }[] = [];
+                
+                for (const category in catalog) {
+                    const skus = (catalog as any)[category] as string[];
+                    skus.forEach(s => {
+                        skusByCategory.push({
+                            label: `${s} (${category})`,
+                            sku: s
+                        });
+                    });
+                }
+                
+                const selected = await vscode.window.showQuickPick(
+                    skusByCategory.map(item => item.label),
+                    { placeHolder: `Select ${provider} SKU to block` }
+                );
+                
+                if (selected) {
+                    sku = skusByCategory.find(item => item.label === selected)?.sku;
+                }
+            }
+            
+            if (sku) {
+                const settings = settingsManager.getSettings();
+                if (settings.skus.blocklist.includes(sku)) {
+                    vscode.window.showWarningMessage(`${sku} is already in the blocklist`);
+                    return;
+                }
+                const blocklist = [...settings.skus.blocklist, sku];
+                await settingsManager.updateSetting('skus.blocklist', blocklist);
+                vscode.window.showInformationMessage(`Added ${sku} to blocklist`);
+                configView.refresh();
+            }
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vaultguard.removeSKUFromBlocklist', async (sku: string) => {
+            const settings = settingsManager.getSettings();
+            const blocklist = settings.skus.blocklist.filter(s => s !== sku);
+            await settingsManager.updateSetting('skus.blocklist', blocklist);
+            vscode.window.showInformationMessage(`Removed ${sku} from blocklist`);
+            configView.refresh();
+        })
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('vaultguard.addCatalogSKUToBlocklist', async (item: any) => {
+            const sku = item.label;
+            const settings = settingsManager.getSettings();
+            if (settings.skus.blocklist.includes(sku)) {
+                vscode.window.showWarningMessage(`${sku} is already in the blocklist`);
+                return;
+            }
+            const blocklist = [...settings.skus.blocklist, sku];
+            await settingsManager.updateSetting('skus.blocklist', blocklist);
+            vscode.window.showInformationMessage(`Added ${sku} to blocklist`);
+            configView.refresh();
+        })
     );
 
     // Register Quick Fix Provider

--- a/src/views/configurationView.ts
+++ b/src/views/configurationView.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { SettingsManager } from '../config/settingsManager';
+import { SKU_CATALOG } from '../config/skuCatalog';
 
 export class ConfigurationViewProvider implements vscode.TreeDataProvider<ConfigItem> {
     private _onDidChangeTreeData: vscode.EventEmitter<ConfigItem | undefined | null | void> = new vscode.EventEmitter<ConfigItem | undefined | null | void>();
@@ -29,7 +30,8 @@ export class ConfigurationViewProvider implements vscode.TreeDataProvider<Config
             // Root level
             return Promise.resolve([
                 new ConfigItem('Rules', 'rules', vscode.TreeItemCollapsibleState.Collapsed),
-                new ConfigItem('SKU Management', 'skus', vscode.TreeItemCollapsibleState.Collapsed)
+                new ConfigItem('SKU Management', 'skus', vscode.TreeItemCollapsibleState.Collapsed),
+                new ConfigItem('SKU Catalog', 'sku-catalog', vscode.TreeItemCollapsibleState.Collapsed)
             ]);
         }
 
@@ -44,14 +46,40 @@ export class ConfigurationViewProvider implements vscode.TreeDataProvider<Config
         if (element.contextValue === 'blocklist') {
             const { blocklist } = this.settingsManager.getSettings().skus;
             return Promise.resolve(blocklist.map(sku => 
-                new ConfigItem(sku, 'sku-item', vscode.TreeItemCollapsibleState.None)
+                new SKUItem(sku, 'blocked-sku')
             ));
         }
 
         if (element.contextValue === 'allowlist') {
             const { allowlist } = this.settingsManager.getSettings().skus;
             return Promise.resolve(allowlist.map(sku => 
-                new ConfigItem(sku, 'sku-item', vscode.TreeItemCollapsibleState.None)
+                new SKUItem(sku, 'allowed-sku')
+            ));
+        }
+
+        // SKU Catalog navigation
+        if (element.contextValue === 'sku-catalog') {
+            return Promise.resolve([
+                new ConfigItem('AWS', 'provider-aws', vscode.TreeItemCollapsibleState.Collapsed),
+                new ConfigItem('Azure', 'provider-azure', vscode.TreeItemCollapsibleState.Collapsed),
+                new ConfigItem('GCP', 'provider-gcp', vscode.TreeItemCollapsibleState.Collapsed)
+            ]);
+        }
+
+        // Cloud provider SKU listings
+        if (element.contextValue?.startsWith('provider-')) {
+            const provider = element.label as 'AWS' | 'Azure' | 'GCP';
+            return Promise.resolve(this.getProviderSKUs(provider));
+        }
+
+        // Category listings (compute, database, etc.)
+        if (element.contextValue?.startsWith('category-')) {
+            const [_, provider, category] = element.contextValue.split('-');
+            const catalog = SKU_CATALOG[provider as 'AWS' | 'Azure' | 'GCP'];
+            const skus = (catalog as any)[category] as string[];
+            const blocklist = this.settingsManager.getSettings().skus.blocklist;
+            return Promise.resolve(skus.map(sku => 
+                new CatalogSKUItem(sku, provider, blocklist.includes(sku))
             ));
         }
 
@@ -87,6 +115,24 @@ export class ConfigurationViewProvider implements vscode.TreeDataProvider<Config
 
         return items;
     }
+
+    private getProviderSKUs(provider: 'AWS' | 'Azure' | 'GCP'): ConfigItem[] {
+        const catalog = SKU_CATALOG[provider];
+        const items: ConfigItem[] = [];
+        
+        for (const category in catalog) {
+            const count = (catalog as any)[category].length;
+            const categoryItem = new ConfigItem(
+                `${category} (${count})`,
+                `category-${provider}-${category}`,
+                vscode.TreeItemCollapsibleState.Collapsed
+            );
+            categoryItem.iconPath = new vscode.ThemeIcon('folder');
+            items.push(categoryItem);
+        }
+        
+        return items;
+    }
 }
 
 class ConfigItem extends vscode.TreeItem {
@@ -119,5 +165,29 @@ class RuleItem extends ConfigItem {
         );
         this.iconPath = new vscode.ThemeIcon(enabled ? 'check' : 'x');
         this.description = enabled ? 'Enabled' : 'Disabled';
+    }
+}
+
+class SKUItem extends ConfigItem {
+    constructor(
+        sku: string,
+        type: 'blocked-sku' | 'allowed-sku'
+    ) {
+        super(sku, type, vscode.TreeItemCollapsibleState.None);
+        this.iconPath = new vscode.ThemeIcon(type === 'blocked-sku' ? 'error' : 'pass');
+    }
+}
+
+class CatalogSKUItem extends ConfigItem {
+    constructor(
+        sku: string,
+        provider: string,
+        isBlocked: boolean
+    ) {
+        const contextValue = isBlocked ? 'catalog-sku-blocked' : 'catalog-sku-available';
+        super(sku, contextValue, vscode.TreeItemCollapsibleState.None);
+        this.description = isBlocked ? '🚫 Blocked' : '';
+        this.iconPath = new vscode.ThemeIcon(isBlocked ? 'error' : 'cloud');
+        this.tooltip = `${provider} SKU: ${sku}`;
     }
 }

--- a/src/views/configurationView.ts
+++ b/src/views/configurationView.ts
@@ -1,0 +1,110 @@
+import * as vscode from 'vscode';
+import { SettingsManager } from '../config/settingsManager';
+
+export class ConfigurationViewProvider implements vscode.TreeDataProvider<ConfigItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<ConfigItem | undefined | null | void> = new vscode.EventEmitter<ConfigItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<ConfigItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+    private settingsManager: SettingsManager;
+
+    constructor() {
+        this.settingsManager = SettingsManager.getInstance();
+        
+        // Refresh view when settings change
+        this.settingsManager.onDidChangeSettings(() => {
+            this.refresh();
+        });
+    }
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: ConfigItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: ConfigItem): Thenable<ConfigItem[]> {
+        if (!element) {
+            // Root level
+            return Promise.resolve([
+                new ConfigItem('Rules', 'rules', vscode.TreeItemCollapsibleState.Collapsed),
+                new ConfigItem('SKU Management', 'skus', vscode.TreeItemCollapsibleState.Collapsed)
+            ]);
+        }
+
+        if (element.contextValue === 'rules') {
+            return Promise.resolve(this.getRuleItems());
+        }
+
+        if (element.contextValue === 'skus') {
+            return Promise.resolve(this.getSKUItems());
+        }
+
+        return Promise.resolve([]);
+    }
+
+    private getRuleItems(): ConfigItem[] {
+        const settings = this.settingsManager.getSettings();
+        return [
+            new RuleItem('Data Residency (OSFI B-10)', 'dataResidency', settings.rules.dataResidency.enabled),
+            new RuleItem('Secrets Detection (OSFI B-13)', 'secrets', settings.rules.secrets.enabled),
+            new RuleItem('Encryption (OSFI B-13)', 'encryption', settings.rules.encryption.enabled),
+            new RuleItem('Portability (OSFI B-10)', 'portability', settings.rules.portability.enabled),
+            new RuleItem('Cost Optimization', 'costOptimization', settings.rules.costOptimization.enabled)
+        ];
+    }
+
+    private getSKUItems(): ConfigItem[] {
+        const { blocklist, allowlist } = this.settingsManager.getSettings().skus;
+        const items: ConfigItem[] = [];
+
+        if (allowlist.length > 0) {
+            const allowlistItem = new ConfigItem('Allowed SKUs', 'allowlist', vscode.TreeItemCollapsibleState.Collapsed);
+            items.push(allowlistItem);
+        }
+
+        if (blocklist.length > 0) {
+            const blocklistItem = new ConfigItem('Blocked SKUs', 'blocklist', vscode.TreeItemCollapsibleState.Collapsed);
+            blocklistItem.description = blocklist.join(', ');
+            items.push(blocklistItem);
+        }
+
+        items.push(new ConfigItem('Add to Blocklist...', 'add-sku', vscode.TreeItemCollapsibleState.None));
+
+        return items;
+    }
+}
+
+class ConfigItem extends vscode.TreeItem {
+    constructor(
+        public readonly label: string,
+        public readonly contextValue: string,
+        public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+        public readonly command?: vscode.Command
+    ) {
+        super(label, collapsibleState);
+        this.contextValue = contextValue;
+    }
+}
+
+class RuleItem extends ConfigItem {
+    constructor(
+        label: string,
+        ruleName: string,
+        enabled: boolean
+    ) {
+         super(
+            label,
+            `rule-${ruleName}`,
+            vscode.TreeItemCollapsibleState.None,
+            {
+                command: 'vaultguard.toggleRule',
+                title: 'Toggle Rule',
+                arguments: [ruleName]
+            }
+        );
+        this.iconPath = new vscode.ThemeIcon(enabled ? 'check' : 'x');
+        this.description = enabled ? 'Enabled' : 'Disabled';
+    }
+}

--- a/src/views/configurationView.ts
+++ b/src/views/configurationView.ts
@@ -41,6 +41,20 @@ export class ConfigurationViewProvider implements vscode.TreeDataProvider<Config
             return Promise.resolve(this.getSKUItems());
         }
 
+        if (element.contextValue === 'blocklist') {
+            const { blocklist } = this.settingsManager.getSettings().skus;
+            return Promise.resolve(blocklist.map(sku => 
+                new ConfigItem(sku, 'sku-item', vscode.TreeItemCollapsibleState.None)
+            ));
+        }
+
+        if (element.contextValue === 'allowlist') {
+            const { allowlist } = this.settingsManager.getSettings().skus;
+            return Promise.resolve(allowlist.map(sku => 
+                new ConfigItem(sku, 'sku-item', vscode.TreeItemCollapsibleState.None)
+            ));
+        }
+
         return Promise.resolve([]);
     }
 
@@ -66,7 +80,6 @@ export class ConfigurationViewProvider implements vscode.TreeDataProvider<Config
 
         if (blocklist.length > 0) {
             const blocklistItem = new ConfigItem('Blocked SKUs', 'blocklist', vscode.TreeItemCollapsibleState.Collapsed);
-            blocklistItem.description = blocklist.join(', ');
             items.push(blocklistItem);
         }
 


### PR DESCRIPTION
## Summary
Implements configuration UI with sidebar panel for managing VaultGuard settings (#6).

## Changes
- ✅ VS Code settings schema with rule toggles
- ✅ Sidebar view with shield icon
- ✅ Configuration TreeView provider
- ✅ SKU allowlist/blocklist management
- ✅ Scanner respects enabled/disabled rules

## Features

### Sidebar Panel
- Click shield icon in activity bar
- View all rules and their status
- Toggle rules on/off with single click
- Manage SKU blocklist

### Settings
All settings accessible via VS Code Settings UI or sidebar:
- `vaultguard.rules.*.enabled` - Toggle individual rules
- `vaultguard.skus.blocklist` - Blocked instance types
- `vaultguard.skus.allowlist` - Allowed instance types (if set, only these allowed)
- `vaultguard.costThreshold` - Monthly cost warning threshold

### Commands
- **Toggle Rule**: Click rule in sidebar to enable/disable
- **Add to Blocklist**: Add SKUs to block via command or sidebar

## Testing
1. Open VaultGuard sidebar (shield icon)
2. Click a rule to toggle it
3. Verify scanner respects disabled rules
4. Add SKU to blocklist
5. Test workspace vs user settings

Fixes #6